### PR TITLE
refactor: BaseEntity 컬럼 명 변경

### DIFF
--- a/src/main/java/com/sparos4th/admin/common/BaseTimeEntity.java
+++ b/src/main/java/com/sparos4th/admin/common/BaseTimeEntity.java
@@ -17,7 +17,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseTimeEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate


### PR DESCRIPTION
BaseEntity 컬럼 명 변경

컬럼명이 안 정해져 있어서 createat이 2개 있는거 확인했습니다